### PR TITLE
Support integer uniforms

### DIFF
--- a/claude_client/ClaudeHandler.py
+++ b/claude_client/ClaudeHandler.py
@@ -25,6 +25,7 @@ class ClaudeHandler(Sender):
     @alias_param(name="iterator", alias="i")
     @alias_param(name="divisor", alias="d")
     @alias_param(name="rate", alias="r")
+    @alias_param(name="datatype", alias="dt")
     def send(
         self,
         name: str,

--- a/claude_client/ClaudeHandler.py
+++ b/claude_client/ClaudeHandler.py
@@ -29,17 +29,12 @@ class ClaudeHandler(Sender):
         self,
         name: str,
         value: Optional[StringElement | List[StringElement]],
+        datatype: str = 'f',
         iterator: Number = 0,
         divisor: NumericElement = 1,
         rate: NumericElement = 1,
         **pattern: ParsableElement,
     ):
-        if name is None or value is None:
-            return
-
-        if self.apply_conditional_mask_to_bars(pattern):
-            return
-
         dims = ['x', 'y', 'z', 'w']
 
         if isinstance(value, list):
@@ -54,7 +49,7 @@ class ClaudeHandler(Sender):
 
         deadline = self.env.clock.shifted_time
         for item in reduced:
-            message = name
+            message = f'{datatype} {name}'
             for dim in dims:
                 if not dim in item:
                     break;

--- a/claude_server/app.py
+++ b/claude_server/app.py
@@ -42,7 +42,7 @@ class ClaudeApp(mglw.WindowConfig):
         self.vao = self.ctx.vertex_array(self.program, vbo, 'in_vert')
 
         # Initialize uniforms
-        self.write_uniform('resolution', ClaudeApp.window_size)
+        self.write_uniform('f4', 'resolution', ClaudeApp.window_size)
 
         # Queue for sending messages from server process to application process
         self.queue = Queue()
@@ -51,22 +51,22 @@ class ClaudeApp(mglw.WindowConfig):
         self.server = Process(target=server_feed, args=(ClaudeApp.ip, ClaudeApp.port, self.queue,))
         self.server.start()
 
-    def write_uniform(self, name, value):
+    def write_uniform(self, np_dtype, name, value):
         try:
-            self.program.get(name, None).write(np.array(value).astype('f4').tobytes())
+            self.program.get(name, None).write(np.array(value).astype(np_dtype).tobytes())
         except Exception:
             pass
 
     def render(self, time, frametime):
         # Prepare next frame
         self.ctx.clear(0.0, 0.0, 0.0, 0.0)
-        self.write_uniform('time', time)
+        self.write_uniform('f4', 'time', time)
 
         # Read messages fed from server and update uniforms accordingly
         while not self.queue.empty():
             try:
                 item = self.queue.get_nowait()
-                self.write_uniform(item['name'], item['value'])
+                self.write_uniform(item['np_dtype'], item['name'], item['value'])
             except Exception:
                 pass
 

--- a/claude_server/server.py
+++ b/claude_server/server.py
@@ -18,10 +18,16 @@ def server_feed(ip: str, port: int, q: Queue):
                 data = conn.recv(1024)
                 try:
                     # Parse message and feed it through queue
-                    msg = data.decode('utf-8').split(' ')
-                    name = msg[0]
-                    value = list(map(float, msg[1:]))
+                    message = data.decode('utf-8').split(' ')
+                    datatype = message[0]
+                    name = message[1]
+                    value = message[2:]
+                    if datatype == 'i':
+                        value = list(map(int, value))
+                    else:
+                        value = list(map(float, value))
                     q.put_nowait({
+                        'np_dtype': 'i4' if datatype == 'i' else 'f4',
                         'name': name,
                         'value': value
                     })

--- a/resources/wave.frag
+++ b/resources/wave.frag
@@ -7,6 +7,7 @@ uniform float freq = 1.0;
 uniform float amp = 0.1;
 uniform vec3 water = vec3(0.0, 0.0, 1.0);
 uniform vec3 sky = vec3(1.0);
+uniform int nb_waves = 1;
 
 out vec3 frag_color;
 
@@ -19,12 +20,13 @@ void main() {
     // Compute Y threshold based on X for wave shape
     float freq_clamped = clamp(freq, 0.1, 100.0);
     float amp_clamped = clamp(amp, 0.01, 1.0);
-    float threshold = sin((time + uv.x) * freq) * amp_clamped;
+    float wave = sin((time + uv.x) * freq) * amp_clamped;
 
-    // Write output color
-    if (uv.y < threshold) {
-        frag_color = water;
-    } else {
-        frag_color = sky;
-    }
+    // Compute wave level based on number of waves
+    float nb_waves_clamped = float(max(nb_waves, 1));
+    float level = floor((uv.y - wave + 1.0) * 0.5 * (nb_waves_clamped + 1.0));
+    float level_clamped = clamp(level, 0, nb_waves_clamped);
+
+    // Compute output color based on level by interpolation
+    frag_color = mix(water, sky, level_clamped / nb_waves_clamped);
 }


### PR DESCRIPTION
## Description

**Server**: receive, parse and use a *datatype* information for the given uniform.

**Sardine client**: send datatype using new `datatype` argument (or `dt` for short).

Only integers and floats are supported for now.

Updated API:
`datatype uniform_name x y z w`
`datatype` can be either `i` or `f`