### PR TITLE
Filewatcher for input fragment shader

### DIFF
--- a/claude_server/__main__.py
+++ b/claude_server/__main__.py
@@ -21,11 +21,9 @@ parser.add_argument('--size', type=int, nargs=2, metavar=('W', 'H'), default=[80
 args = parser.parse_args()
 
 # Register resources directories
-register_dir((Path(__file__).parents[1] / 'resources').resolve())
-if not args.res:
-    register_dir(Path.cwd())
-else:
-    register_dir(args.res)
+ClaudeApp.resource_dir = (Path(__file__).parents[1] / 'resources').resolve()
+if args.res:
+    ClaudeApp.resource_dir = args.res
 
 # Configuration
 ClaudeApp.fragment_shader = args.frag

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pkg_resources==0.0.0
 pyglet==2.0.7
 pyrr==0.10.3
 six==1.16.0
+watchdog==3.0.0


### PR DESCRIPTION
## Description

Create a *filewatcher* to reload the input fragment shader whenever it is modified on disk.

This allows to interactively edit the shader during a session.

## Remarks

Adds a dependency to `watchdog`.