### PR TITLE
fix server CLI

### DIFF
--- a/claude_server/__main__.py
+++ b/claude_server/__main__.py
@@ -1,5 +1,6 @@
 from claude_server.app import ClaudeApp
 
+from moderngl_window import run_window_config
 from moderngl_window.resources import register_dir
 
 from argparse import ArgumentParser
@@ -33,4 +34,4 @@ ClaudeApp.title = args.title
 ClaudeApp.window_size = (args.size[0], args.size[1])
 
 # Start application
-ClaudeApp.run()
+run_window_config(ClaudeApp, args=['-wnd', 'pyglet'])

--- a/claude_server/app.py
+++ b/claude_server/app.py
@@ -80,7 +80,9 @@ class ClaudeApp(mglw.WindowConfig):
 
     def write_uniform(self, np_dtype, name, value, caching = True):
         try:
-            self.program.get(name, None).write(np.array(value).astype(np_dtype).tobytes())
+            uniform = self.program.get(name, None)
+            if uniform:
+                uniform.write(np.array(value).astype(np_dtype).tobytes())
         except Exception as e:
             print(e)
             return


### PR DESCRIPTION
## Description

By defaut `moderngl_window.WindowConfig` catches and tries to parse `sys.argv`.
We need to override that behavior to avoid invalid argument errors.